### PR TITLE
Export all of the types for development purposes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import got from 'got'
 import * as domino from 'domino'
 
 import { Options, Context, RuleSet, MetaData } from './types'
+
+export * from './types'
+
 import { metaDataRules } from './rules'
 
 const defaultOptions = {


### PR DESCRIPTION
Say I want to create a wrapper for the lib (or prepare some settings),
availability of those types will help me much.

Usage example:

```ts
import { Options } from 'metadata-scraper';

const myCustomOptions: Options = {
  // ...
}
```

And alike.

WDYT?