### PR TITLE
Update rules to include product type

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -267,5 +267,13 @@ export const metaDataRules: Record<string, RuleSet> = {
 			[ 'meta[name="og:audio"][content]', (element) => element.getAttribute('content') ]
 		],
 		processor: (imageUrl: any, context) => context.options.forceImageHttps === true ? makeUrlSecure(makeUrlAbsolute(context.url, imageUrl)) : makeUrlAbsolute(context.url, imageUrl)
+	},
+	product: {
+		rules: [
+			[ 'meta[property="product:brand"][content]', (element) => element.getAttribute('content') ],
+			[ 'meta[property="product:price:amount"][content]', (element) => element.getAttribute('content') ],
+			[ 'meta[property="product:price:currency"][content]', (element) => element.getAttribute('content') ],
+			[ 'meta[property="product:availability"][content]', (element) => element.getAttribute('content') ],
+		]
 	}
 }


### PR DESCRIPTION
I have a use case in my app where I need to get the meta data of a product on the page if available, so I have added in some custom rules. Thought It would be good to add them back into the package as well.